### PR TITLE
Add pwndbg context dumper with support for mips/mipsel

### DIFF
--- a/unicorn_mode/helper_scripts/unicorn_dumper_pwndbg.py
+++ b/unicorn_mode/helper_scripts/unicorn_dumper_pwndbg.py
@@ -18,7 +18,7 @@
       source <path_to_pwndbg>/gdbinit.py
 
     Call this function when at a breakpoint in your process with:
-      source unicorn_dumper_pwngdb.py
+      source unicorn_dumper_pwndbg.py
 
     -----------
 

--- a/unicorn_mode/helper_scripts/unicorn_dumper_pwndbg.py
+++ b/unicorn_mode/helper_scripts/unicorn_dumper_pwndbg.py
@@ -1,0 +1,192 @@
+"""
+    unicorn_dumper_gdb.py
+    
+    When run with GDB sitting at a debug breakpoint, this
+    dumps the current state (registers/memory/etc) of
+    the process to a directory consisting of an index 
+    file with register and segment information and 
+    sub-files containing all actual process memory.
+    
+    The output of this script is expected to be used 
+    to initialize context for Unicorn emulation.
+
+    -----------
+
+    In order to run this script, GEF needs to be running in the GDB session (gef.py)
+    # HELPERS from: https://github.com/hugsy/gef/blob/master/gef.py
+    It can be loaded with:
+      source <path_to_gef>/gef.py
+
+    Call this function when at a breakpoint in your process with:
+      source unicorn_dumper_gdb.py
+
+    -----------
+
+
+"""
+
+import datetime
+import hashlib
+import json
+import os
+import sys
+import time
+import zlib
+
+# GDB Python SDK
+import gdb
+
+# Maximum segment size that we'll store
+# Yep, this could break stuff pretty quickly if we
+# omit something that's used during emulation.
+MAX_SEG_SIZE = 128 * 1024 * 1024
+
+# Name of the index file
+INDEX_FILE_NAME = "_index.json"
+
+#----------------------
+#---- Helper Functions
+
+def map_arch():
+    arch = get_arch() # from GEF
+    if 'x86_64' in arch or 'x86-64' in arch:
+        return "x64"
+    elif 'x86' in arch or 'i386' in arch:
+        return "x86"
+    elif 'aarch64' in arch or 'arm64' in arch:
+        return "arm64le"
+    elif 'aarch64_be' in arch:
+        return "arm64be"
+    elif 'armeb' in arch:
+        # check for THUMB mode
+        cpsr = get_register('cpsr')
+        if (cpsr & (1 << 5)):
+            return "armbethumb"
+        else:
+            return "armbe"
+    elif 'arm' in arch:
+        # check for THUMB mode
+        cpsr = get_register('cpsr')
+        if (cpsr & (1 << 5)):
+            return "armlethumb"
+        else:
+            return "armle"
+    elif 'mips' in arch:
+        return 'mips'
+    else:
+        return ""
+
+
+#-----------------------
+#---- Dumping functions
+
+def dump_arch_info():
+    arch_info = {}
+    arch_info["arch"] = map_arch()
+    return arch_info
+
+
+def dump_regs():
+    reg_state = {}
+    for reg in current_arch.all_registers:
+        reg_val = get_register(reg)
+        # current dumper script looks for register values to be hex strings
+#         reg_str = "0x{:08x}".format(reg_val)
+#         if "64" in get_arch():
+#             reg_str = "0x{:016x}".format(reg_val)
+#         reg_state[reg.strip().strip('$')] = reg_str
+        reg_state[reg.strip().strip('$')] = reg_val
+    return reg_state
+
+
+def dump_process_memory(output_dir):
+    # Segment information dictionary
+    final_segment_list = []
+    
+    # GEF:
+    vmmap = get_process_maps()
+    if not vmmap:
+        print("No address mapping information found")
+        return final_segment_list
+
+    for entry in vmmap:
+        if entry.page_start == entry.page_end:
+            continue
+        
+        seg_info = {'start': entry.page_start, 'end': entry.page_end, 'name': entry.path, 'permissions': {
+            "r": entry.is_readable() > 0,
+            "w": entry.is_writable() > 0,
+            "x": entry.is_executable() > 0
+        }, 'content_file': ''}
+
+        # "(deleted)" may or may not be valid, but don't push it.
+        if entry.is_readable() and not '(deleted)' in entry.path:
+            try:
+                # Compress and dump the content to a file
+                seg_content = read_memory(entry.page_start, entry.size)
+                if(seg_content == None):
+                    print("Segment empty: @0x{0:016x} (size:UNKNOWN) {1}".format(entry.page_start, entry.path))
+                else:
+                    print("Dumping segment @0x{0:016x} (size:0x{1:x}): {2} [{3}]".format(entry.page_start, len(seg_content), entry.path, repr(seg_info['permissions'])))
+                    compressed_seg_content = zlib.compress(seg_content)
+                    md5_sum = hashlib.md5(compressed_seg_content).hexdigest() + ".bin"
+                    seg_info["content_file"] = md5_sum
+                    
+                    # Write the compressed contents to disk
+                    out_file = open(os.path.join(output_dir, md5_sum), 'wb')
+                    out_file.write(compressed_seg_content)
+                    out_file.close()
+
+            except:
+                print("Exception reading segment ({}): {}".format(entry.path, sys.exc_info()[0]))
+        else:
+            print("Skipping segment {0}@0x{1:016x}".format(entry.path, entry.page_start))
+
+        # Add the segment to the list
+        final_segment_list.append(seg_info)
+
+            
+    return final_segment_list
+
+#----------
+#---- Main    
+    
+def main():
+    print("----- Unicorn Context Dumper -----")
+    print("You must be actively debugging before running this!")
+    print("If it fails, double check that you are actively debugging before running.")
+    try:
+        GEF_TEST = set_arch()
+    except Exception as e:
+        print("!!! GEF not running in GDB.  Please run gef.py by executing:")
+        print('\tpython execfile ("<path_to_gef>/gef.py")')
+        return
+    
+    try:
+    
+        # Create the output directory
+        timestamp = datetime.datetime.fromtimestamp(time.time()).strftime('%Y%m%d_%H%M%S')
+        output_path = "UnicornContext_" + timestamp
+        if not os.path.exists(output_path):
+            os.makedirs(output_path)
+        print("Process context will be output to {}".format(output_path))
+            
+        # Get the context
+        context = {
+            "arch": dump_arch_info(),
+            "regs": dump_regs(), 
+            "segments": dump_process_memory(output_path),
+        }
+
+        # Write the index file
+        index_file = open(os.path.join(output_path, INDEX_FILE_NAME), 'w')
+        index_file.write(json.dumps(context, indent=4))
+        index_file.close()    
+        print("Done.")
+        
+    except Exception as e:
+        print("!!! ERROR:\n\t{}".format(repr(e)))
+        
+if __name__ == "__main__":
+    main()
+    

--- a/unicorn_mode/helper_scripts/unicorn_dumper_pwndbg.py
+++ b/unicorn_mode/helper_scripts/unicorn_dumper_pwndbg.py
@@ -71,20 +71,21 @@ def map_arch():
         return "arm64le"
     elif 'aarch64_be' in arch:
         return "arm64be"
-    elif 'armeb' in arch:
-        # check for THUMB mode
-        cpsr = get_register('cpsr')
-        if (cpsr & (1 << 5)):
-            return "armbethumb"
-        else:
-            return "armbe"
     elif 'arm' in arch:
-        # check for THUMB mode
-        cpsr = get_register('cpsr')
-        if (cpsr & (1 << 5)):
-            return "armlethumb"
+        cpsr = pwndbg.regs['cpsr']
+        # check endianess 
+        if pwndbg.arch.endian == 'big':
+            # check for THUMB mode
+            if (cpsr & (1 << 5)):
+                return "armbethumb"
+            else:
+                return "armbe"
         else:
-            return "armle"
+            # check for THUMB mode
+            if (cpsr & (1 << 5)):
+                return "armlethumb"
+            else:
+                return "armle"
     elif 'mips' in arch:
         if pwndbg.arch.endian == 'little':
             return 'mipsel'

--- a/unicorn_mode/helper_scripts/unicorn_loader.py
+++ b/unicorn_mode/helper_scripts/unicorn_loader.py
@@ -365,6 +365,7 @@ class AflUnicornEngine(Uc):
             "armle"     : [ UC_ARM_REG_PC,      UC_ARCH_ARM,    UC_MODE_ARM | UC_MODE_LITTLE_ENDIAN ],
             "armbethumb": [ UC_ARM_REG_PC,      UC_ARCH_ARM,    UC_MODE_THUMB | UC_MODE_BIG_ENDIAN ],
             "armlethumb": [ UC_ARM_REG_PC,      UC_ARCH_ARM,    UC_MODE_THUMB | UC_MODE_LITTLE_ENDIAN ],
+            "mips"      : [ UC_MIPS_REG_PC,     UC_ARCH_MIPS,   UC_MODE_MIPS32 | UC_MODE_BIG_ENDIAN ],
         }
         return (arch_map[arch_str][1], arch_map[arch_str][2])
 
@@ -472,6 +473,44 @@ class AflUnicornEngine(Uc):
                 "lr":     UC_ARM64_REG_LR,
                 "nzcv":   UC_ARM64_REG_NZCV,
                 "cpsr": UC_ARM_REG_CPSR, 
+            },
+            "mips" : {
+                "0" :     UC_MIPS_REG_ZERO,
+                "at":     UC_MIPS_REG_AT,
+                "v0":     UC_MIPS_REG_V0,
+                "v1":     UC_MIPS_REG_V1,
+                "a0":     UC_MIPS_REG_A0,
+                "a1":     UC_MIPS_REG_A1,
+                "a2":     UC_MIPS_REG_A2,
+                "a3":     UC_MIPS_REG_A3,
+                "t0":     UC_MIPS_REG_T0,
+                "t1":     UC_MIPS_REG_T1,
+                "t2":     UC_MIPS_REG_T2,
+                "t3":     UC_MIPS_REG_T3,
+                "t4":     UC_MIPS_REG_T4,
+                "t5":     UC_MIPS_REG_T5,
+                "t6":     UC_MIPS_REG_T6,
+                "t7":     UC_MIPS_REG_T7,
+                "t8":     UC_MIPS_REG_T8,
+                "t9":     UC_MIPS_REG_T9,
+                "s0":     UC_MIPS_REG_S0,
+                "s1":     UC_MIPS_REG_S1,
+                "s2":     UC_MIPS_REG_S2,    
+                "s3":     UC_MIPS_REG_S3,
+                "s4":     UC_MIPS_REG_S4,
+                "s5":     UC_MIPS_REG_S5,
+                "s6":     UC_MIPS_REG_S6,              
+                "s7":     UC_MIPS_REG_S7,
+                "s8":     UC_MIPS_REG_S8,  
+                "k0":     UC_MIPS_REG_K0,
+                "k1":     UC_MIPS_REG_K1,
+                "gp":     UC_MIPS_REG_GP,
+                "pc":     UC_MIPS_REG_PC,
+                "sp":     UC_MIPS_REG_SP,
+                "fp":     UC_MIPS_REG_FP,
+                "ra":     UC_MIPS_REG_RA,
+                "hi":     UC_MIPS_REG_HI,
+                "lo":     UC_MIPS_REG_LO
             }
         }
         return registers[arch]   

--- a/unicorn_mode/helper_scripts/unicorn_loader.py
+++ b/unicorn_mode/helper_scripts/unicorn_loader.py
@@ -367,7 +367,7 @@ class AflUnicornEngine(Uc):
             "armbethumb": [ UC_ARM_REG_PC,      UC_ARCH_ARM,    UC_MODE_THUMB | UC_MODE_BIG_ENDIAN ],
             "armlethumb": [ UC_ARM_REG_PC,      UC_ARCH_ARM,    UC_MODE_THUMB | UC_MODE_LITTLE_ENDIAN ],
             "mips"      : [ UC_MIPS_REG_PC,     UC_ARCH_MIPS,   UC_MODE_MIPS32 | UC_MODE_BIG_ENDIAN ],
-            "mipsel"      : [ UC_MIPS_REG_PC,     UC_ARCH_MIPS,   UC_MODE_MIPS32 | UC_MODE_LITTLE_ENDIAN ],
+            "mipsel"    : [ UC_MIPS_REG_PC,     UC_ARCH_MIPS,   UC_MODE_MIPS32 | UC_MODE_LITTLE_ENDIAN ],
         }
         return (arch_map[arch_str][1], arch_map[arch_str][2])
 

--- a/unicorn_mode/helper_scripts/unicorn_loader.py
+++ b/unicorn_mode/helper_scripts/unicorn_loader.py
@@ -24,6 +24,7 @@ from unicorn import *
 from unicorn.arm_const import *
 from unicorn.arm64_const import *
 from unicorn.x86_const import *
+from unicorn.mips_const import *
 
 # Name of the index file
 INDEX_FILE_NAME = "_index.json"
@@ -366,6 +367,7 @@ class AflUnicornEngine(Uc):
             "armbethumb": [ UC_ARM_REG_PC,      UC_ARCH_ARM,    UC_MODE_THUMB | UC_MODE_BIG_ENDIAN ],
             "armlethumb": [ UC_ARM_REG_PC,      UC_ARCH_ARM,    UC_MODE_THUMB | UC_MODE_LITTLE_ENDIAN ],
             "mips"      : [ UC_MIPS_REG_PC,     UC_ARCH_MIPS,   UC_MODE_MIPS32 | UC_MODE_BIG_ENDIAN ],
+            "mipsel"      : [ UC_MIPS_REG_PC,     UC_ARCH_MIPS,   UC_MODE_MIPS32 | UC_MODE_LITTLE_ENDIAN ],
         }
         return (arch_map[arch_str][1], arch_map[arch_str][2])
 
@@ -374,6 +376,8 @@ class AflUnicornEngine(Uc):
             arch = "arm64"
         elif arch == "armle" or arch == "armbe" or "thumb" in arch:
             arch = "arm"
+        elif arch == "mipsel":
+            arch = "mips"
 
         registers = {
             "x64" : {


### PR DESCRIPTION
I've added a context dumper script to work with [pwndbg](pwndbg.com) for it's higher compatibility with qemu as compared to gef. This will allow for us to dump the context of any architecture supported by qemu. 

Also, I've added support for mips and mipsel #6 whose context can be extracted by first emulating on qemu and then dumped by unicorn_dumper_pwndbg.py via remote debugging on pwndbg. 

I've currently tested it on mips, mipsel, x86_64 and arm_be. 

Thanks for your work!