### PR TITLE
Floating point regs for ARM

### DIFF
--- a/unicorn_mode/helper_scripts/unicorn_dumper_gdb.py
+++ b/unicorn_mode/helper_scripts/unicorn_dumper_gdb.py
@@ -44,6 +44,7 @@ MAX_SEG_SIZE = 128 * 1024 * 1024
 # Name of the index file
 INDEX_FILE_NAME = "_index.json"
 
+
 #----------------------
 #---- Helper Functions
 
@@ -88,11 +89,6 @@ def dump_regs():
     reg_state = {}
     for reg in current_arch.all_registers:
         reg_val = get_register(reg)
-        # current dumper script looks for register values to be hex strings
-#         reg_str = "0x{:08x}".format(reg_val)
-#         if "64" in get_arch():
-#             reg_str = "0x{:016x}".format(reg_val)
-#         reg_state[reg.strip().strip('$')] = reg_str
         reg_state[reg.strip().strip('$')] = reg_val
 
     return reg_state
@@ -147,20 +143,21 @@ def dump_process_memory(output_dir):
 
     return final_segment_list
 
-#-----------------------
+#---------------------------------------------
 #---- ARM Extention (dump floating point regs)
 
 def dump_float(rge=32):
     reg_convert = ""
-    reg_state = {}
-    # Get all floating point registers
-    for reg_num in range(32):
-        value = gdb.selected_frame().read_register("d" + str(reg_num))
-        reg_state["d" + str(reg_num)] = int(str(value["u64"]), 16)
-    value = gdb.selected_frame().read_register("fpscr")
-    reg_state["fpscr"] = int(str(value), 16)
+    if map_arch() == "armbe" or map_arch() == "armle" or map_arch() == "armbethumb" or map_arch() == "armbethumb":
+        reg_state = {}
+        for reg_num in range(32):
+            value = gdb.selected_frame().read_register("d" + str(reg_num))
+            reg_state["d" + str(reg_num)] = int(str(value["u64"]), 16)
+        value = gdb.selected_frame().read_register("fpscr")
+        reg_state["fpscr"] = int(str(value), 16)
 
-    return reg_state
+        return reg_state
+
 #----------
 #---- Main
 

--- a/unicorn_mode/helper_scripts/unicorn_dumper_gdb.py
+++ b/unicorn_mode/helper_scripts/unicorn_dumper_gdb.py
@@ -1,13 +1,13 @@
 """
     unicorn_dumper_gdb.py
-    
+
     When run with GDB sitting at a debug breakpoint, this
     dumps the current state (registers/memory/etc) of
-    the process to a directory consisting of an index 
-    file with register and segment information and 
+    the process to a directory consisting of an index
+    file with register and segment information and
     sub-files containing all actual process memory.
-    
-    The output of this script is expected to be used 
+
+    The output of this script is expected to be used
     to initialize context for Unicorn emulation.
 
     -----------
@@ -101,7 +101,7 @@ def dump_regs():
 def dump_process_memory(output_dir):
     # Segment information dictionary
     final_segment_list = []
-    
+
     # GEF:
     vmmap = get_process_maps()
     if not vmmap:
@@ -111,7 +111,7 @@ def dump_process_memory(output_dir):
     for entry in vmmap:
         if entry.page_start == entry.page_end:
             continue
-        
+
         seg_info = {'start': entry.page_start, 'end': entry.page_end, 'name': entry.path, 'permissions': {
             "r": entry.is_readable() > 0,
             "w": entry.is_writable() > 0,
@@ -130,7 +130,7 @@ def dump_process_memory(output_dir):
                     compressed_seg_content = zlib.compress(seg_content)
                     md5_sum = hashlib.md5(compressed_seg_content).hexdigest() + ".bin"
                     seg_info["content_file"] = md5_sum
-                    
+
                     # Write the compressed contents to disk
                     out_file = open(os.path.join(output_dir, md5_sum), 'wb')
                     out_file.write(compressed_seg_content)
@@ -144,7 +144,7 @@ def dump_process_memory(output_dir):
         # Add the segment to the list
         final_segment_list.append(seg_info)
 
-            
+
     return final_segment_list
 
 #-----------------------
@@ -153,6 +153,7 @@ def dump_process_memory(output_dir):
 def dump_float(rge=32):
     reg_convert = ""
     reg_state = {}
+    # Get all floating point registers
     for reg_num in range(32):
         value = gdb.selected_frame().read_register("d" + str(reg_num))
         reg_state["d" + str(reg_num)] = int(str(value["u64"]), 16)
@@ -161,8 +162,8 @@ def dump_float(rge=32):
 
     return reg_state
 #----------
-#---- Main    
-    
+#---- Main
+
 def main():
     print("----- Unicorn Context Dumper -----")
     print("You must be actively debugging before running this!")
@@ -173,16 +174,16 @@ def main():
         print("!!! GEF not running in GDB.  Please run gef.py by executing:")
         print('\tpython execfile ("<path_to_gef>/gef.py")')
         return
-    
+
     try:
-    
+
         # Create the output directory
         timestamp = datetime.datetime.fromtimestamp(time.time()).strftime('%Y%m%d_%H%M%S')
         output_path = "UnicornContext_" + timestamp
         if not os.path.exists(output_path):
             os.makedirs(output_path)
         print("Process context will be output to {}".format(output_path))
-            
+
         # Get the context
         context = {
             "arch": dump_arch_info(),
@@ -194,12 +195,11 @@ def main():
         # Write the index file
         index_file = open(os.path.join(output_path, INDEX_FILE_NAME), 'w')
         index_file.write(json.dumps(context, indent=4))
-        index_file.close()    
+        index_file.close()
         print("Done.")
-        
+
     except Exception as e:
         print("!!! ERROR:\n\t{}".format(repr(e)))
-        
+
 if __name__ == "__main__":
     main()
-    

--- a/unicorn_mode/helper_scripts/unicorn_dumper_gdb.py
+++ b/unicorn_mode/helper_scripts/unicorn_dumper_gdb.py
@@ -94,6 +94,7 @@ def dump_regs():
 #             reg_str = "0x{:016x}".format(reg_val)
 #         reg_state[reg.strip().strip('$')] = reg_str
         reg_state[reg.strip().strip('$')] = reg_val
+
     return reg_state
 
 
@@ -146,6 +147,19 @@ def dump_process_memory(output_dir):
             
     return final_segment_list
 
+#-----------------------
+#---- ARM Extention (dump floating point regs)
+
+def dump_float(rge=32):
+    reg_convert = ""
+    reg_state = {}
+    for reg_num in range(32):
+        value = gdb.selected_frame().read_register("d" + str(reg_num))
+        reg_state["d" + str(reg_num)] = int(str(value["u64"]), 16)
+    value = gdb.selected_frame().read_register("fpscr")
+    reg_state["fpscr"] = int(str(value), 16)
+
+    return reg_state
 #----------
 #---- Main    
     
@@ -172,7 +186,8 @@ def main():
         # Get the context
         context = {
             "arch": dump_arch_info(),
-            "regs": dump_regs(), 
+            "regs": dump_regs(),
+            "regs_extended": dump_float(),
             "segments": dump_process_memory(output_path),
         }
 

--- a/unicorn_mode/helper_scripts/unicorn_loader.py
+++ b/unicorn_mode/helper_scripts/unicorn_loader.py
@@ -187,9 +187,10 @@ class AflUnicornEngine(Uc):
         self.__load_registers(regs, reg_map, debug_print)
         # If we have extra FLOATING POINT regs, load them in!
         if 'regs_extended' in context:
-            regs_extended = context['regs_extended']
-            reg_map = self.__get_registers_extended(self._arch_str)
-            self.__load_registers(regs_extended, reg_map, debug_print)
+		if context['regs_extended']:
+		    regs_extended = context['regs_extended']
+		    reg_map = self.__get_registers_extended(self._arch_str)
+		    self.__load_registers(regs_extended, reg_map, debug_print)
 
         # For ARM, sometimes the stack pointer is erased ??? (I think I fixed this (issue with ordering of dumper.py, I'll keep the write anyways)
         if self.__get_arch_and_mode(self.get_arch_str())[0] == UC_ARCH_ARM:

--- a/unicorn_mode/helper_scripts/unicorn_loader.py
+++ b/unicorn_mode/helper_scripts/unicorn_loader.py
@@ -185,11 +185,15 @@ class AflUnicornEngine(Uc):
         regs = context['regs']
         reg_map = self.__get_register_map(self._arch_str)
         self.__load_registers(regs, reg_map, debug_print)
-        # If extended registers were dumped, load them as well
+        # If we have extra FLOATING POINT regs, load them in!
         if 'regs_extended' in context:
             regs_extended = context['regs_extended']
             reg_map = self.__get_registers_extended(self._arch_str)
             self.__load_registers(regs_extended, reg_map, debug_print)
+
+        # For ARM, sometimes the stack pointer is erased ??? (I think I fixed this (issue with ordering of dumper.py, I'll keep the write anyways)
+        if self.__get_arch_and_mode(self.get_arch_str())[0] == UC_ARCH_ARM:
+            self.reg_write(UC_ARM_REG_SP, regs['sp'])
 
         # Setup the memory map and load memory content
         self.__map_segments(context['segments'], context_directory, debug_print)
@@ -237,12 +241,12 @@ class AflUnicornEngine(Uc):
             print(">>> {0:>4}: 0x{1:016x}".format(reg[0], self.reg_read(reg[1])))
 
     def dump_regs_extended(self):
-        """ Dumps the contents of all the FLOATING POINT registers to STDOUT """
-	    try:
+        """ Dumps the contents of all the registers to STDOUT """
+        try:
             for reg in sorted(self.__get_registers_extended(self._arch_str).items(), key=lambda reg: reg[0]):
                 print(">>> {0:>4}: 0x{1:016x}".format(reg[0], self.reg_read(reg[1])))
-        except:
-            print("ERROR @dump_regs_extended: are there extended registers?")
+        except Exception as e:
+            print("ERROR: Are extended registers loaded?")
 
     # TODO: Make this dynamically get the stack pointer register and pointer width for the current architecture
     """


### PR DESCRIPTION
Hi! I currently work a lot with ARM.

**I decided to add an additional functionality to the unicorn_dumper and unicorn_loader that should allow users using ARM architecture to dump extra registers, specially the floating registers, which in ARM are d0 to d31**

If not using ARM, the code runs the exact same as if it was never changed.  Otherwise, the added function dump_regs_extended allows to dump these floating registers.

**This was heavily tested on ARM, but not on other architectures (although it should work fine)**

If there are any issues/specific changes you would like me to make, please let me know!