### PR TITLE
Git pulls unicorn v1 branch without unicorn2

### DIFF
--- a/unicorn_mode/build_unicorn_support.sh
+++ b/unicorn_mode/build_unicorn_support.sh
@@ -119,7 +119,7 @@ fi
 
 echo "[*] Downloading Unicorn from github..."
 rm -r "unicorn"
-git clone "$UNICORN_URL" || exit 1
+git clone "$UNICORN_URL" --branch v1 || exit 1
 
 echo "[*] Applying patches..."
 


### PR DESCRIPTION
Hi, 

above all，thank you for your outstanding work. We are still using your alf-unicorn to try to fuzz IoT firmware. :)

The upstream Unicorn has been updated to version 2.0.0. Unicorn2 has updated a lot of code, causing the afl unicorn patches to fail to work properly. Therefore, we should use the v1 of Unicorn Engine.


