### PR TITLE
Use a modern method to check for setuptools installation.

### DIFF
--- a/unicorn_mode/build_unicorn_support.sh
+++ b/unicorn_mode/build_unicorn_support.sh
@@ -91,7 +91,7 @@ for i in wget python automake autoconf sha384sum; do
 
 done
 
-if ! which easy_install > /dev/null; then
+if ! python -c "import sys; import setuptools; print(setuptools.version.__version__)" &> /dev/null; then
 
   echo "[-] Error: Python setup-tools not found. Run 'sudo apt-get install python-setuptools'."
   exit 1


### PR DESCRIPTION
Fixes #17.

easy_install is deprecated (see https://setuptools.pypa.io/en/latest/deprecated/easy_install.html), so modern machines will not have it available. This PR changes the unicorn support script to check for the setuptools package, rather than only the easy_install script, which is a more modern method (see the suggested methods in https://stackoverflow.com/a/56683743)

It works on my machine (Fedora Linux 37, Python 3.11.1). I also tested it on Docker official Python 3.6 image: https://hub.docker.com/_/python, tag `python:3.6`.